### PR TITLE
Add x86 build workflow and rename Pekora strings to Korone

### DIFF
--- a/.github/workflows/build-simple.yml
+++ b/.github/workflows/build-simple.yml
@@ -1,0 +1,38 @@
+name: Build x86 Simple
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: windows-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      
+    - name: Setup MSBuild
+      uses: microsoft/setup-msbuild@v1.3
+      
+    - name: Setup vcpkg
+      uses: lukka/run-vcpkg@v11
+      with:
+        vcpkgDirectory: '${{ github.workspace }}/vcpkg'
+        vcpkgGitCommitId: 'latest'
+        vcpkgJsonGlob: 'vcpkg.json'
+        vcpkgTriplet: 'x86-windows-static'
+        
+    - name: Build Solution
+      run: |
+        msbuild "Installer.sln" /p:Configuration=Release /p:Platform=Win32 /p:VcpkgEnabled=true /p:VcpkgUseStatic=true /p:VcpkgTriplet=x86-windows-static
+        
+    - name: Upload executable
+      uses: actions/upload-artifact@v4
+      with:
+        name: KoronePlayerLauncher-x86
+        path: BootstrapperClient\bin\Release\Win32\KoronePlayerLauncher.exe
+        retention-days: 7

--- a/.github/workflows/build-x86.yml
+++ b/.github/workflows/build-x86.yml
@@ -1,0 +1,100 @@
+name: Build x86 (Win32) Release
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: windows-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      
+    - name: Setup MSBuild
+      uses: microsoft/setup-msbuild@v1.3
+      
+    - name: Setup vcpkg
+      uses: lukka/run-vcpkg@v11
+      with:
+        vcpkgDirectory: '${{ github.workspace }}/vcpkg'
+        vcpkgGitCommitId: '7e19f3c64cb636ee21f41bfe8558a6dfaae6236f'
+        vcpkgJsonGlob: 'vcpkg.json'
+        runVcpkgInstall: '--triplet=x86-windows-static --x-wait-for-lock'
+        
+    - name: Set vcpkg environment
+      run: |
+        echo "VCPKG_ROOT=${{ github.workspace }}/vcpkg" >> $env:GITHUB_ENV
+        echo "VCPKG_DEFAULT_TRIPLET=x86-windows-static" >> $env:GITHUB_ENV
+        echo "CMAKE_WARN_UNUSED_CLI_VARS=OFF" >> $env:GITHUB_ENV
+        echo "VCPKG_CMAKE_CONFIGURE_OPTIONS=-DCMAKE_WARN_UNUSED_CLI_VARS=OFF" >> $env:GITHUB_ENV
+        
+    - name: Integrate vcpkg with MSBuild
+      run: |
+        & "${{ github.workspace }}/vcpkg/vcpkg.exe" integrate install
+        
+    - name: Build Solution
+      run: |
+        msbuild "Installer.sln" /p:Configuration=Release /p:Platform=Win32 /p:VcpkgEnabled=true /p:VcpkgUseStatic=true /p:VcpkgTriplet=x86-windows-static
+        
+    - name: Verify executable exists
+      run: |
+        if (Test-Path "BootstrapperClient\bin\Release\Win32\KoronePlayerLauncher.exe") {
+          Write-Host "KoronePlayerLauncher.exe built successfully!"
+          Get-Item "BootstrapperClient\bin\Release\Win32\KoronePlayerLauncher.exe" | Select-Object Name, Length, LastWriteTime
+        } else {
+          Write-Host "KoronePlayerLauncher.exe not found!"
+          Get-ChildItem -Recurse -Name "*.exe" | ForEach-Object { Write-Host "Found: $_" }
+          exit 1
+        }
+        
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: KoronePlayerLauncher-x86-Release
+        path: |
+          BootstrapperClient\bin\Release\Win32\KoronePlayerLauncher.exe
+        retention-days: 30
+        
+    - name: Create release package
+      if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
+      run: |
+        $version = Get-Date -Format "yyyy.MM.dd-HHmm"
+        $zipName = "KoronePlayerLauncher-x86-$version.zip"
+        
+        # create a temporary dir for packaging
+        New-Item -ItemType Directory -Path "release-package" -Force
+        
+        # copy the exe
+        Copy-Item "BootstrapperClient\bin\Release\Win32\KoronePlayerLauncher.exe" "release-package\"
+        
+        # create README for the release
+        $readmeText = "# KoronePlayerLauncher (x86)`n`n"
+        $readmeText += "Build Date: $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss UTC')`n"
+        $readmeText += "Commit: ${{ github.sha }}`n"
+        $readmeText += "Platform: Windows x86 (32-bit)`n`n"
+        $readmeText += "## Installation`n"
+        $readmeText += "1. Download KoronePlayerLauncher.exe`n"
+        $readmeText += "2. Run the executable`n`n"
+        $readmeText += "## Requirements`n"
+        $readmeText += "- Windows 7 or later`n"
+        $readmeText += "- Visual C++ Redistributable (if not already installed)"
+        $readmeText | Out-File -FilePath "release-package\README.txt" -Encoding UTF8
+        
+        # create the zip file
+        Compress-Archive -Path "release-package\*" -DestinationPath $zipName -Force
+        
+        Write-Host "Created release package: $zipName"
+        Get-Item $zipName | Select-Object Name, Length
+        
+    - name: Upload release package
+      if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
+      uses: actions/upload-artifact@v4
+      with:
+        name: Release-Package-x86
+        path: "KoronePlayerLauncher-x86-*.zip"
+        retention-days: 90

--- a/Bootstrapper/Bootstrapper.cpp
+++ b/Bootstrapper/Bootstrapper.cpp
@@ -181,7 +181,7 @@ public:
 				else
 				{
 					CString message;
-					message.Format(_T("An error occured and Pekora cannot continue.\n\n%S"), e.what());
+					message.Format(_T("An error occured and Korone cannot continue.\n\n%S"), e.what());
 					::MessageBox(NULL, message, _T("Error"), MB_OK | MB_ICONEXCLAMATION);
 				}
 				result = -1;
@@ -935,7 +935,7 @@ boost::shared_ptr<Bootstrapper> Bootstrapper::Create(HINSTANCE hInstance, Bootst
 			CTimedMutexLock l1(m1);
 			if (l1.Lock(1) == WAIT_TIMEOUT)
 			{
-				LLOG_ENTRY(result->logger, "No bg update, Pekora App is running");
+				LLOG_ENTRY(result->logger, "No bg update, Korone App is running");
 				return result;
 			}
 
@@ -1060,7 +1060,7 @@ void Bootstrapper::RegisterUninstall(const TCHAR *productName)
 	
 	std::wstring uninstallString = format_string(_T("\"%s%s\" -uninstall%s"), programDirectory().c_str(), GetBootstrapperFileName().c_str(), perUser ? _T("") : _T(" -alluser"));
 	throwHRESULT (keyProductCode->SetStringValue(_T("UninstallString"), uninstallString.c_str(), REG_EXPAND_SZ), "Failed to set UninstallString key");
-	throwHRESULT (keyProductCode->SetStringValue(_T("Publisher"), _T("Pekora Corporation")), "Failed to set Publisher key");
+	throwHRESULT (keyProductCode->SetStringValue(_T("Publisher"), _T("Korone Corporation")), "Failed to set Publisher key");
 	throwHRESULT (keyProductCode->SetStringValue(_T("URLInfoAbout"), _T("http://pekora.zip")), "Failed to set URLInfoAbout key");
 	throwHRESULT (keyProductCode->SetStringValue(_T("Comments"), convert_s2w(installVersion).c_str()), "Failed to set Comments key");
 	throwHRESULT (keyProductCode->SetStringValue(_T("InstallLocation"), programDirectory().c_str()), "Failed to set InstallLocation key");
@@ -1107,7 +1107,7 @@ void Bootstrapper::RegisterProtocolHandler(const std::wstring& protocolScheme, c
 
 	// register the protocol handler scheme
 	auto key = CreateKey(isPerUser() ? HKEY_CURRENT_USER : HKEY_LOCAL_MACHINE, (_T("SOFTWARE\\Classes\\") + protocolScheme).c_str());
-	throwHRESULT(key->SetStringValue(_T(""), _T("URL: Pekora Protocol")), format_string("failed to set value for protocol"));
+	throwHRESULT(key->SetStringValue(_T(""), _T("URL: Korone Protocol")), format_string("failed to set value for protocol"));
 	throwHRESULT(key->SetStringValue(_T("URL Protocol"), _T("")), format_string("failed to set value for protocol"));
 
 	CreateKey(key->m_hKey, _T("DefaultIcon"), exePath.c_str());
@@ -1386,7 +1386,7 @@ bool Bootstrapper::checkBootstrapperVersion()
 	moduleVersionNumber = vi.GetFileVersionAsString();
 	LOG_ENTRY1("module file version: %s", moduleVersionNumber.c_str());
 
-	message("Connecting to Pekora...");
+	message("Connecting to Korone...");
 	try
 	{
 		installVersion = fetchVersionGuid(); // TODO: Why is this setting the installVersion?
@@ -1469,7 +1469,7 @@ bool Bootstrapper::checkBootstrapperVersion()
 
 			try
 			{
-				message("Getting the latest Pekora...");
+				message("Getting the latest Korone...");
 
 				// We could use an "exe" extension, but hiding the type isn't a bad idea?
 				newBootstrapper = simple_logger<wchar_t>::get_temp_filename(_T("tmp"));
@@ -1488,7 +1488,7 @@ bool Bootstrapper::checkBootstrapperVersion()
 					std::ofstream bootstrapperFile(newBootstrapper.c_str(), std::ios::binary);
 					// this we might need during rollback, lets be on safe side
 					std::string eTag;
-					HttpTools::httpGetCdn(this, installHost, format_string("/%s-Pekora.exe", installVersion.c_str()), eTag, bootstrapperFile, false, boost::bind(&Bootstrapper::dummyProgress, _1, _2));
+					HttpTools::httpGetCdn(this, installHost, format_string("/%s-Korone.exe", installVersion.c_str()), eTag, bootstrapperFile, false, boost::bind(&Bootstrapper::dummyProgress, _1, _2));
 				}
 			}
 
@@ -1517,7 +1517,7 @@ bool Bootstrapper::checkBootstrapperVersion()
 
 void Bootstrapper::writeAppSettings()
 {
-	message("Configuring Pekora...");
+	message("Configuring Korone...");
 
 	std::wstring appSettings(programDirectory() + _T("AppSettings.xml"));
 	std::ofstream file(appSettings.c_str());
@@ -1661,7 +1661,7 @@ void Bootstrapper::checkOSPrerequisit()
 
 	LOG_ENTRY("checkOSPrerequisit failed");
 	if (windowed)
-		dialog->DisplayError("Pekora requires Microsoft Windows XP SP1 or greater", NULL);
+		dialog->DisplayError("Korone requires Microsoft Windows XP SP1 or greater", NULL);
 	throw installer_error_exception(installer_error_exception::OsPrerequisite);
 }
 
@@ -1671,7 +1671,7 @@ void Bootstrapper::checkCPUPrerequisit()
 	{
 		LOG_ENTRY("checkCPUPrerequisit failed");
 	    if (windowed)
-		    dialog->DisplayError("Pekora requires SSE2 support", NULL);
+		    dialog->DisplayError("Korone requires SSE2 support", NULL);
 		throw installer_error_exception(installer_error_exception::CpuPrerequisite);
 	}
 }
@@ -1696,7 +1696,7 @@ void Bootstrapper::checkIEPrerequisit()
 	{
 		LOG_ENTRY("checkIEPrerequisit failed");
 		if (windowed)
-			dialog->DisplayError("Pekora requires Microsoft Internet Explorer 6.0 or greater", NULL);
+			dialog->DisplayError("Korone requires Microsoft Internet Explorer 6.0 or greater", NULL);
 		throw installer_error_exception(installer_error_exception::IePrerequisite);
 	}
 }
@@ -1866,7 +1866,7 @@ void Bootstrapper::checkDiskSpace()
 	::GetDiskFreeSpaceEx(programDirectory().c_str(), &freeBytesAvailableToCaller, NULL, NULL);
 	if (freeBytesAvailableToCaller.QuadPart < 40*1e6)
 	{
-		dialog->DisplayError("There is not enough room on your disk to install Pekora. Please free up some space and try again.", NULL);
+		dialog->DisplayError("There is not enough room on your disk to install Korone. Please free up some space and try again.", NULL);
 		throw installer_error_exception(installer_error_exception::DiskSpacePrerequisite);
 	}
 }
@@ -1931,10 +1931,10 @@ void Bootstrapper::run()
 			LOG_ENTRY("Error: IsNetworkAlive failed");
 			if (windowed && isLatestProcess())
 			{
-				CString message = _T("Pekora cannot connect to the Internet\n\nDoes your computer have a working network connection?  Is antivirus software preventing Roblox from accessing the Internet?");
+				CString message = _T("Korone cannot connect to the Internet\n\nDoes your computer have a working network connection?  Is antivirus software preventing Roblox from accessing the Internet?");
 				if (!robloxAppArgs.empty())
 				{
-					message += _T("\n\nIf you Pekora may not work properly.");
+					message += _T("\n\nIf you Korone may not work properly.");
 					// TODO: CTaskDialog should use nice command buttons
 					if (dialog->MessageBox(message, _T("Error"), MB_OKCANCEL | MB_ICONEXCLAMATION) == IDOK)
 					{
@@ -1962,10 +1962,10 @@ void Bootstrapper::run()
 
 			if (windowed && isLatestProcess())
 			{
-				CString message = _T("Cannot connect to the Pekora.\n\nIs antivirus software preventing Pekora from accessing the Internet?");
+				CString message = _T("Cannot connect to the Korone.\n\nIs antivirus software preventing Korone from accessing the Internet?");
 				if (!robloxAppArgs.empty())
 				{
-					message += _T("\n\nIf you continue Pekora may not work properly.");
+					message += _T("\n\nIf you continue Korone may not work properly.");
 					if (dialog->MessageBox(message, _T("Error"), MB_OKCANCEL | MB_ICONEXCLAMATION) == IDOK)
 					{
 						installVersion = queryInstalledVersion();
@@ -1986,7 +1986,7 @@ void Bootstrapper::run()
 			if (queryInstalledVersion() != installVersion)
 				throw non_zero_exit_exception();
 
-			LOG_ENTRY("Pekora is up to date, returning success");
+			LOG_ENTRY("Korone is up to date, returning success");
 			goto done;
 		}
 
@@ -2234,7 +2234,7 @@ void Bootstrapper::run()
 	catch (non_zero_exit_exception&)
 	{
 		exitCode = 1;
-		LOG_ENTRY("Pekora is not up to date, returning failure");
+		LOG_ENTRY("Korone is not up to date, returning failure");
 	}
 	catch (silent_exception&)
 	{
@@ -2723,7 +2723,7 @@ void Bootstrapper::install()
 			if (!perUser && !IsAdminRunning())
 			{
 				if (windowed)
-					dialog->DisplayError("On this machine you must install Pekora using an Administrator account", NULL);
+					dialog->DisplayError("On this machine you must install Korone using an Administrator account", NULL);
 				throw installer_error_exception(installer_error_exception::AdminAccountRequired);
 			}
 		}

--- a/Bootstrapper/Bootstrapper.rc
+++ b/Bootstrapper/Bootstrapper.rc
@@ -98,7 +98,7 @@ END
 
 IDD_MAIN DIALOGEX 0, 0, 207, 61
 STYLE DS_SETFONT | DS_MODALFRAME | DS_SETFOREGROUND | DS_CENTER | WS_POPUP | WS_CAPTION | WS_SYSMENU
-CAPTION "Pekora"
+CAPTION "Korone"
 FONT 10, "Segoe UI", 400, 0, 0x0
 BEGIN
     PUSHBUTTON      "Cancel",IDCANCEL,147,37,50,14,NOT WS_VISIBLE
@@ -141,12 +141,12 @@ BEGIN
     BEGIN
         BLOCK "040904b0"
         BEGIN
-            VALUE "CompanyName", "Pekora Corporation"
-            VALUE "FileDescription", "Pekora"
+            VALUE "CompanyName", "Korone Corporation"
+            VALUE "FileDescription", "Korone"
             VALUE "FileVersion", "1, 7, 0, 0"
-            VALUE "LegalCopyright", "(C) 2025 Pekora Corporation.  All rights reserved."
-            VALUE "OriginalFilename", "Pekora.exe"
-            VALUE "ProductName", "Pekora Bootstrapper"
+            VALUE "LegalCopyright", "(C) 2025 Korone Corporation.  All rights reserved."
+            VALUE "OriginalFilename", "Korone.exe"
+            VALUE "ProductName", "Korone Bootstrapper"
             VALUE "ProductVersion", "1, 7, 0, 0"
         END
     END
@@ -184,9 +184,9 @@ STRINGTABLE
 BEGIN
     IDS_INSTALLHOST         "setup.pekora.zip"
     IDS_BASEHOST            "www.pekora.zip"
-    IDS_SUCCESS1            "Pekora IS SUCCESSFULLY INSTALLED!"
+    IDS_SUCCESS1            "Korone IS SUCCESSFULLY INSTALLED!"
     IDS_SUCCESS2            "Just click the ""Play"" button on any game to join the action!"
-    IDS_STUDIO_SUCCESS1     "Pekora STUDIO IS SUCCESSFULLY INSTALLED!"
+    IDS_STUDIO_SUCCESS1     "Korone STUDIO IS SUCCESSFULLY INSTALLED!"
     IDS_STUDIO_SUCCESS2     "Click ""Launch Studio"" to make your new game!"
 END
 

--- a/Bootstrapper/Bootstrapper.vcxproj
+++ b/Bootstrapper/Bootstrapper.vcxproj
@@ -54,6 +54,7 @@
     <PlatformToolset>v143</PlatformToolset>
     <UseOfAtl>Static</UseOfAtl>
     <CharacterSet>Unicode</CharacterSet>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -80,8 +81,8 @@
     <PostBuildEventUseInBuild>false</PostBuildEventUseInBuild>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OutDir>$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>bin\$(Configuration)\$(PlatformName)\</OutDir>
+    <IntDir>obj\$(Configuration)\$(PlatformName)\</IntDir>
     <PostBuildEventUseInBuild>false</PostBuildEventUseInBuild>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -99,6 +100,9 @@
     <VcpkgUseStatic>true</VcpkgUseStatic>
   </PropertyGroup>
   <PropertyGroup Label="Vcpkg" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <VcpkgUseStatic>true</VcpkgUseStatic>
+  </PropertyGroup>
+  <PropertyGroup Label="Vcpkg" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <VcpkgUseStatic>true</VcpkgUseStatic>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -137,12 +141,13 @@
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>$(CONTRIB_PATH)\boost_1_84_0\boost\include;$(CONTRIB_PATH)\boost_1_560\src;..\ClientShared;..\RBXCookies;..\Win;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;BOOST_THREAD_BUILD_LIB;BOOST_CHRONO_HEADER_ONLY;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <MinimalRebuild>true</MinimalRebuild>
+      <MinimalRebuild>false</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <LanguageStandard>stdcpp23</LanguageStandard>
     </ClCompile>
     <PostBuildEvent>
       <Command />

--- a/Bootstrapper/FileDeployer.cpp
+++ b/Bootstrapper/FileDeployer.cpp
@@ -26,7 +26,7 @@ std::wstring FileDeployer::downloadVersionedFile(const TCHAR* name, Progress& pr
 	if (downloadsDirectory.empty())
 		throw std::runtime_error("Failed to create Downloads folder"); 
 
-	auto key = CreateKey(_perUser ? HKEY_CURRENT_USER : HKEY_LOCAL_MACHINE, _T("Software\\PekoraReg\\ETags"));
+	auto key = CreateKey(_perUser ? HKEY_CURRENT_USER : HKEY_LOCAL_MACHINE, _T("Software\\KoroneReg\\ETags"));
 
 	std::string etag = QueryStringValue(key, name);
 
@@ -235,7 +235,7 @@ void FileDeployer::cleanupVersionedFile(const std::wstring& name, const std::wst
 		}
 
 		//Clear out the etag registry cache, just in case our file delete did not work
-		auto key = CreateKey(_perUser ? HKEY_CURRENT_USER : HKEY_LOCAL_MACHINE, _T("Software\\PekoraReg\\ETags"));
+		auto key = CreateKey(_perUser ? HKEY_CURRENT_USER : HKEY_LOCAL_MACHINE, _T("Software\\KoroneReg\\ETags"));
 		key->SetStringValue(name.c_str(), _T(""));
 	}
 	catch(std::exception&)

--- a/Bootstrapper/FileSystem.cpp
+++ b/Bootstrapper/FileSystem.cpp
@@ -11,7 +11,7 @@ std::wstring FileSystem::getSpecialFolder(FolderType folder, bool create, const 
 	std::string robloxDir = "";
 	if (appendRoblox)
 	{
-		robloxDir = "\\Pekora";
+		robloxDir = "\\Korone";
 	}
 		
 	switch (folder)

--- a/Bootstrapper/LegacyDialog.cpp
+++ b/Bootstrapper/LegacyDialog.cpp
@@ -152,12 +152,12 @@ void CLegacyDialog::DisplayError(const char* message, const char* exceptionText)
 		text += "\n\nDetails: ";
 		text += exceptionText;
 	}
-	MessageBox(convert_s2w(text).c_str(), _T("Pekora"), MB_OK | MB_ICONERROR);
+	MessageBox(convert_s2w(text).c_str(), _T("Korone"), MB_OK | MB_ICONERROR);
 }
 
 void CLegacyDialog::FinalMessage(const char* message)
 {
-	MessageBox(convert_s2w(message).c_str(), _T("Pekora"), MB_OK);
+	MessageBox(convert_s2w(message).c_str(), _T("Korone"), MB_OK);
 }
 
 void CLegacyDialog::SetCancelEnabled(bool state)

--- a/Bootstrapper/ProgressDialog.cpp
+++ b/Bootstrapper/ProgressDialog.cpp
@@ -370,12 +370,12 @@ void CProgressDialog::DisplayError(const char* message, const char* exceptionTex
 		text += "\n\nDetails: ";
 		text += exceptionText;
 	}
-	MessageBox(convert_s2w(text).c_str(), _T("Pekora"), MB_OK | MB_ICONERROR);
+	MessageBox(convert_s2w(text).c_str(), _T("Korone"), MB_OK | MB_ICONERROR);
 }
 
 void CProgressDialog::FinalMessage(const char* message)
 {
-	MessageBox(convert_s2w(message).c_str(), _T("Pekora"), MB_OK);
+	MessageBox(convert_s2w(message).c_str(), _T("Korone"), MB_OK);
 }
 
 void CProgressDialog::SetCancelEnabled(bool state)

--- a/Bootstrapper/Roblox.inf
+++ b/Bootstrapper/Roblox.inf
@@ -2,7 +2,7 @@
     signature="$CHICAGO$"
     AdvancedINF=2.0 
 [Add.Code]
-    Pekora.exe=Pekora.exe
-[Pekora.exe]
+    Korone.exe=Korone.exe
+[Korone.exe]
     file-win32-x86=thiscab
     clsid={5FF8A30F-D08D-41CD-A03A-10346903902B}

--- a/Bootstrapper/SharedHelpers.cpp
+++ b/Bootstrapper/SharedHelpers.cpp
@@ -208,7 +208,7 @@ void deleteCurVersionKeys(simple_logger<wchar_t> &logger, bool isPerUser, const 
 {
 	CRegKey key;
 	LOG_ENTRY("deleteCurVersionKeys");
-	if(!FAILED(key.Open(isPerUser ? HKEY_CURRENT_USER : HKEY_LOCAL_MACHINE, _T("Software\\Pekora Corporation\\Pekora"), KEY_WRITE)))
+	if(!FAILED(key.Open(isPerUser ? HKEY_CURRENT_USER : HKEY_LOCAL_MACHINE, _T("Software\\Korone Corporation\\Korone"), KEY_WRITE)))
 	{
 		LOG_ENTRY("deleteCurVersionKeys - key Opened");
 		key.DeleteValue(buildVersionKey(component).c_str());
@@ -220,7 +220,7 @@ void setCurrentVersion(simple_logger<wchar_t> &logger, bool isPerUser, const TCH
 {
 	CRegKey key;
 	LOG_ENTRY3("setCurrentVersion - opening write registry key component=%S, version=%S, url=%S", componentCode, version, baseUrl);
-	if (ERROR_SUCCESS == key.Create(isPerUser ? HKEY_CURRENT_USER : HKEY_LOCAL_MACHINE, _T("Software\\Pekora Corporation\\Pekora")))
+	if (ERROR_SUCCESS == key.Create(isPerUser ? HKEY_CURRENT_USER : HKEY_LOCAL_MACHINE, _T("Software\\Korone Corporation\\Korone")))
 	{
 		std::wstring vKey = buildVersionKey(componentCode);
 		std::wstring uKey = buildUrlKey(componentCode);
@@ -241,7 +241,7 @@ void getCurrentVersion(simple_logger<wchar_t> &logger, bool isPerUser, const TCH
 	LOG_ENTRY1("getCurrentVersion - opening read registry key component=%S", componentCode);
 	version[0] = 0;
 	baseUrl[0] = 0;
-	if (ERROR_SUCCESS == key.Open(isPerUser ? HKEY_CURRENT_USER : HKEY_LOCAL_MACHINE, _T("Software\\Pekora Corporation\\Pekora"), KEY_READ))
+	if (ERROR_SUCCESS == key.Open(isPerUser ? HKEY_CURRENT_USER : HKEY_LOCAL_MACHINE, _T("Software\\Korone Corporation\\Korone"), KEY_READ))
 	{
 		std::wstring vKey = buildVersionKey(componentCode);
 		std::wstring uKey = buildUrlKey(componentCode);
@@ -291,7 +291,7 @@ std::wstring getQTStudioCode()
 void appendEnvironmentToProtocolScheme(std::wstring& scheme, const std::string baseUrl)
 {
 	std::vector<std::string> baseHostUrlParts = splitOn(baseUrl, '.');
-	if (baseHostUrlParts[1] != "pekora")
+	if (baseHostUrlParts[1] != "korone")
 	{
 		scheme += convert_s2w("-" + baseHostUrlParts[1]);
 	}
@@ -299,7 +299,7 @@ void appendEnvironmentToProtocolScheme(std::wstring& scheme, const std::string b
 
 std::wstring getPlayerProtocolScheme(const std::string& baseUrl)
 {
-	std::wstring scheme = _T("pekora-player");
+	std::wstring scheme = _T("korone-player");
 
 	appendEnvironmentToProtocolScheme(scheme, baseUrl);
 
@@ -308,7 +308,7 @@ std::wstring getPlayerProtocolScheme(const std::string& baseUrl)
 
 std::wstring getQTStudioProtocolScheme(const std::string& baseUrl)
 {
-	std::wstring scheme = _T("pekora-studio");
+	std::wstring scheme = _T("korone-studio");
 
 	appendEnvironmentToProtocolScheme(scheme, baseUrl);
 
@@ -317,7 +317,7 @@ std::wstring getQTStudioProtocolScheme(const std::string& baseUrl)
 
 std::wstring getStudioRegistrySubPath()
 {
-	return _T("StudioPekoraReg");
+	return _T("StudioKoroneReg");
 }
 
 std::wstring getStudioRegistryPath()
@@ -456,7 +456,7 @@ void updateExistingRobloxShortcuts(
 				bool isMFCStudio = (StrCmp(exeName, _T(STUDIOBOOTSTAPPERNAME)) == 0); // true if we're updating for MFC studio
 				LOG_ENTRY1("updateExistingRobloxShortcuts isStudio = %d", isMFCStudio);
 
-				if (StrStr(foundFilePath, _T("Pekora.exe")))
+				if (StrStr(foundFilePath, _T("Korone.exe")))
 				{
 					// this shortcut points to the player
 					TCHAR args[MAX_PATH];

--- a/Bootstrapper/SharedHelpers.h
+++ b/Bootstrapper/SharedHelpers.h
@@ -70,13 +70,13 @@ private:
 #define FIREFOXREGKEY               "@nsroblox.pekora.zip/launcher"
 #define FIREFOXREGKEY64             "@nsroblox.pekora.zip/launcher64"
 
-#define PLAYERLINKNAME_CUR          "Pekora Player"
-#define PLAYERLINKNAMELEGACY        "Play Pekora"
+#define PLAYERLINKNAME_CUR          "Korone Player"
+#define PLAYERLINKNAMELEGACY        "Play Korone"
 
 // MFC Studio names
 #define STUDIOEXENAME               "ProjectXStudioBeta.exe"
 #define STUDIOBOOTSTAPPERNAME       "ProjectXStudioBeta.exe"
-#define STUDIOLINKNAMELEGACY        "Pekora Studio"    // wrong case
+#define STUDIOLINKNAMELEGACY        "Korone Studio"    // wrong case
 
 // QT Studio names
 #define STUDIOQTEXENAME             "ProjectXStudioBeta.exe"

--- a/Bootstrapper/ShutdownDialog.cpp
+++ b/Bootstrapper/ShutdownDialog.cpp
@@ -153,7 +153,7 @@ public:
 		, taskWnd(NULL)
 		, dialogResult(-1)
 	{
-		sprintf_s(instructions, 256, "Pekora needs to close \"%s\"", windowTitle);
+		sprintf_s(instructions, 256, "Korone needs to close \"%s\"", windowTitle);
 		boost::thread(boost::bind(&CShutdownTaskDialog::run, this, instance, parent));
 	}
 	~CShutdownTaskDialog(void)
@@ -174,7 +174,7 @@ public:
 		config.hwndParent = parent;
 		config.dwCommonButtons = TDCBF_CANCEL_BUTTON;
 		config.pszMainIcon = MAKEINTRESOURCEW(IDI_BOOTSTRAPPER);
-		config.pszWindowTitle = L"Pekora";
+		config.pszWindowTitle = L"Korone";
 		CComBSTR bstr(instructions);
 		config.pszMainInstruction = (BSTR)bstr;
 
@@ -237,7 +237,7 @@ public:
 	{
 		CString message;
 		message.Format(_T("\"%s\" needs to close.\n\nShut down now?  You may lose work that you haven't saved"), windowTitle);
-		result = ::MessageBox(parent, message, _T("Pekora"), MB_OKCANCEL | MB_ICONQUESTION);
+		result = ::MessageBox(parent, message, _T("Korone"), MB_OKCANCEL | MB_ICONQUESTION);
 	}
 
 	void CloseDialog(void)

--- a/Bootstrapper/TaskDialog.cpp
+++ b/Bootstrapper/TaskDialog.cpp
@@ -175,8 +175,8 @@ void CTaskDialog::run()
 	config.hInstance = instance;
 	config.dwCommonButtons = TDCBF_CANCEL_BUTTON;
 	config.pszMainIcon = MAKEINTRESOURCEW(IDI_BOOTSTRAPPER);
-	config.pszWindowTitle = L"Pekora";
-	config.pszMainInstruction = L"Starting Pekora";
+	config.pszWindowTitle = L"Korone";
+	config.pszMainInstruction = L"Starting Korone";
 	if (RBX_TDE_MESSAGE == TDE_EXPANDED_INFORMATION)
 	{
 		config.pszExpandedInformation = L"Please Wait...";		// http://msdn.microsoft.com/en-us/library/bb760536(VS.85).aspx states: If pszExpandedInformation is NULL and you attempt to send a TDM_UPDATE_ELEMENT_TEXT with TDE_EXPANDED_INFORMATION, nothing will happen.
@@ -264,7 +264,7 @@ void CTaskDialog::DisplayError(const char* message, const char* exceptionText)
 	config.hInstance = NULL;
 	config.dwCommonButtons = TDCBF_CLOSE_BUTTON;
 	config.pszMainIcon = TD_ERROR_ICON;
-	config.pszWindowTitle = L"Pekora";
+	config.pszWindowTitle = L"Korone";
 	CComBSTR btsr(message);
 	config.pszMainInstruction = btsr;
 	CComBSTR btsr2(exceptionText);
@@ -284,7 +284,7 @@ void CTaskDialog::FinalMessage(const char* message)
 	config.hInstance = NULL;
 	config.dwCommonButtons = TDCBF_OK_BUTTON;
 	config.pszMainIcon = MAKEINTRESOURCEW(IDI_BOOTSTRAPPER);
-	config.pszWindowTitle = L"Pekora";
+	config.pszWindowTitle = L"Korone";
 	CComBSTR btsr(message);
 	config.pszMainInstruction = btsr;
 

--- a/BootstrapperClient/BootstrapperClient.cpp
+++ b/BootstrapperClient/BootstrapperClient.cpp
@@ -24,13 +24,13 @@
 #include "ClientProgressDialog.h"
 #include "RobloxServicesTools.h"
 
-static const TCHAR* BootstrapperFileName    = _T("PekoraPlayerLauncher.exe");
+static const TCHAR* BootstrapperFileName    = _T("KoronePlayerLauncher.exe");
 static const TCHAR* RobloxAppFileName		= _T(PLAYEREXENAME);
 static const TCHAR* BootstrapperMutexName   = _T("www.pekora.zip/bootstrapper");
 static const TCHAR* StartRobloxAppMutex     = _T("www.pekora.zip/startRobloxApp");
-static const TCHAR* LauncherFileName        = _T("PekoraProxy.dll");
-static const TCHAR* LauncherFileName64      = _T("PekoraProxy64.dll");
-static const TCHAR* FriendlyName            = _T("Pekora");
+static const TCHAR* LauncherFileName        = _T("KoroneProxy.dll");
+static const TCHAR* LauncherFileName64      = _T("KoroneProxy64.dll");
+static const TCHAR* FriendlyName            = _T("Korone");
 static const TCHAR* CLSID_Launcher          = _T("{76D50904-6780-4c8b-8986-1A7EE0B1716D}");
 static const TCHAR* CLSID_Launcher64        = _T("{DEE03C2B-0C0C-41A9-9877-FD4B4D7B6EA3}");
 static const TCHAR* AppID_Launcher          = _T("{664B192B-D17A-4921-ABF9-C6F6264E5110}");
@@ -68,7 +68,7 @@ BootstrapperClient::BootstrapperClient(HINSTANCE hInstance)
 
 	//Plugin depends on RobloxReg value as well, 
 	//so if you ever change this guy make sure that plugins code is updates as well
-	_regSubPath = L"PekoraReg";
+	_regSubPath = L"KoroneReg";
 	_regPath = L"SOFTWARE\\" + _regSubPath;
 	_versionFileName = L"ProjectXVersion.txt";
 	_versionGuidName = _T(VERSIONGUIDNAMEPLAYER);
@@ -487,7 +487,7 @@ bool BootstrapperClient::NeedPreDeployRun()
 	}
 
 	CRegKey key;
-	if (SUCCEEDED(key.Open(HKEY_CURRENT_USER, _T("Software\\Pekora Corporation\\Pekora"), KEY_READ)))
+	if (SUCCEEDED(key.Open(HKEY_CURRENT_USER, _T("Software\\Korone Corporation\\Korone"), KEY_READ)))
 	{
 		TCHAR buf[MAX_PATH];
 		ULONG bufSize = MAX_PATH;
@@ -539,7 +539,7 @@ void BootstrapperClient::RunPreDeploy()
 		DeployComponents(true, false);
 
 		CRegKey key;
-		if (SUCCEEDED(key.Create(HKEY_CURRENT_USER, _T("Software\\Pekora Corporation\\Pekora"))))
+		if (SUCCEEDED(key.Create(HKEY_CURRENT_USER, _T("Software\\Korone Corporation\\Korone"))))
 		{
 			key.SetStringValue(_T("LastPreVersion"), convert_s2w(preVersion).c_str());
 			LOG_ENTRY("Setting last pre deploy version entry");
@@ -698,7 +698,7 @@ void BootstrapperClient::StartRobloxApp(bool fromInstall)
 	CTimedMutexLock lock(mutex);
 	while (lock.Lock(1) == WAIT_TIMEOUT )
 	{
-		LOG_ENTRY("Another process is starting Pekora. Abandoning startRobloxApp");
+		LOG_ENTRY("Another process is starting Korone. Abandoning startRobloxApp");
 		return;
 	}
 
@@ -706,7 +706,7 @@ void BootstrapperClient::StartRobloxApp(bool fromInstall)
 
 	setStage(10);
 
-	message("Starting Pekora...");
+	message("Starting Korone...");
 
 	LOG_ENTRY("Creating event");
 	CEvent robloxStartedEvent(NULL, TRUE, FALSE, _T("www.pekora.zip/robloxStartedEvent"));
@@ -1053,8 +1053,8 @@ void BootstrapperClient::registerFirefoxPlugin(const TCHAR* id, bool is64Bits)
 	auto key = CreateKey(parent, format_string(_T("SOFTWARE\\MozillaPlugins\\%s"), id).c_str(), NULL, is64Bits);
 
 	key->SetStringValue(_T("ProductName"), _T("Launcher"));
-	key->SetStringValue(_T("Description"), _T("Pekora Launcher"));
-	key->SetStringValue(_T("Vendor"), _T("Pekora"));
+	key->SetStringValue(_T("Description"), _T("Korone Launcher"));
+	key->SetStringValue(_T("Vendor"), _T("Korone"));
 	key->SetStringValue(_T("Version"), _T("1"));
 
 	if (is64Bits)

--- a/BootstrapperClient/BootstrapperClient.vcproj
+++ b/BootstrapperClient/BootstrapperClient.vcproj
@@ -73,7 +73,7 @@
 			<Tool
 				Name="VCLinkerTool"
 				AdditionalDependencies="$(CONTRIB_PATH)\SDK\Lib\Iphlpapi.lib $(CONTRIB_PATH)\SDK\Lib\taskschd.lib $(CONTRIB_PATH)\SDK\Lib\mstask.lib"
-				OutputFile="$(OutDir)\PekoraPlayerLauncher.exe"
+				OutputFile="$(OutDir)\KoronePlayerLauncher.exe"
 				LinkIncremental="2"
 				GenerateDebugInformation="true"
 				SubSystem="2"
@@ -155,7 +155,7 @@
 			<Tool
 				Name="VCLinkerTool"
 				AdditionalDependencies="$(CONTRIB_PATH)\SDK\Lib\Iphlpapi.lib $(CONTRIB_PATH)\SDK\Lib\taskschd.lib $(CONTRIB_PATH)\SDK\Lib\mstask.lib"
-				OutputFile="$(OutDir)\PekoraPlayerLauncher.exe"
+				OutputFile="$(OutDir)\KoronePlayerLauncher.exe"
 				LinkIncremental="2"
 				GenerateDebugInformation="true"
 				SubSystem="2"
@@ -238,7 +238,7 @@
 			<Tool
 				Name="VCLinkerTool"
 				AdditionalDependencies="$(CONTRIB_PATH)\SDK\Lib\Iphlpapi.lib $(CONTRIB_PATH)\SDK\Lib\taskschd.lib $(CONTRIB_PATH)\SDK\Lib\mstask.lib"
-				OutputFile="$(OutDir)\PekoraPlayerLauncher.exe"
+				OutputFile="$(OutDir)\KoronePlayerLauncher.exe"
 				LinkIncremental="2"
 				GenerateDebugInformation="true"
 				SubSystem="2"
@@ -323,7 +323,7 @@
 			<Tool
 				Name="VCLinkerTool"
 				AdditionalDependencies="$(CONTRIB_PATH)\SDK\Lib\Iphlpapi.lib $(CONTRIB_PATH)\SDK\Lib\taskschd.lib $(CONTRIB_PATH)\SDK\Lib\mstask.lib"
-				OutputFile="$(OutDir)\PekoraPlayerLauncher.exe"
+				OutputFile="$(OutDir)\KoronePlayerLauncher.exe"
 				LinkIncremental="2"
 				GenerateDebugInformation="true"
 				SubSystem="2"

--- a/BootstrapperClient/BootstrapperClient.vcxproj
+++ b/BootstrapperClient/BootstrapperClient.vcxproj
@@ -54,6 +54,7 @@
     <PlatformToolset>v143</PlatformToolset>
     <UseOfAtl>Static</UseOfAtl>
     <CharacterSet>Unicode</CharacterSet>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -82,10 +83,11 @@
     <TargetName>KoronePlayerLauncher</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <OutDir>$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>bin\$(Configuration)\$(PlatformName)\</OutDir>
+    <IntDir>obj\$(Configuration)\$(PlatformName)\</IntDir>
     <LinkIncremental>true</LinkIncremental>
     <PostBuildEventUseInBuild>true</PostBuildEventUseInBuild>
+    <TargetName>KoronePlayerLauncher</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <OutDir>bin\$(Configuration)\$(PlatformName)\</OutDir>
@@ -108,6 +110,12 @@
     <VcpkgUseStatic>true</VcpkgUseStatic>
   </PropertyGroup>
   <PropertyGroup Label="Vcpkg" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <VcpkgUseStatic>true</VcpkgUseStatic>
+  </PropertyGroup>
+  <PropertyGroup Label="Vcpkg" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <VcpkgUseStatic>true</VcpkgUseStatic>
+  </PropertyGroup>
+  <PropertyGroup Label="Vcpkg" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <VcpkgUseStatic>true</VcpkgUseStatic>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -149,21 +157,33 @@
     </Midl>
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\Bootstrapper;$(CONTRIB_PATH)\boost_1_84_0\boost\include;$(CONTRIB_PATH)\boost_1_84_0\src;..\Win;..\ClientShared;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\Bootstrapper;..\Win;..\ClientShared;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_WINDOWS;BOOST_THREAD_BUILD_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <MinimalRebuild>true</MinimalRebuild>
+      <MinimalRebuild>false</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <LanguageStandard>stdcpp23</LanguageStandard>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
     </ClCompile>
     <Link>
+<<<<<<< Updated upstream
       <AdditionalDependencies>$(CONTRIB_PATH)\SDK\Lib\Iphlpapi.lib;$(CONTRIB_PATH)\SDK\Lib\taskschd.lib;$(CONTRIB_PATH)\SDK\Lib\mstask.lib;%(AdditionalDependencies)</AdditionalDependencies>
+<<<<<<< Updated upstream
       <OutputFile>$(OutDir)KoronePlayerLauncher.exe</OutputFile>
+=======
+      <OutputFile>$(OutDir)PekoraPlayerLauncher.exe</OutputFile>
+=======
+      <AdditionalDependencies>Iphlpapi.lib;taskschd.lib;mstask.lib;crypt32.lib;secur32.lib;bcrypt.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <OutputFile>$(OutDir)KoronePlayerLauncher.exe</OutputFile>
+>>>>>>> Stashed changes
+>>>>>>> Stashed changes
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <TargetMachine>MachineX64</TargetMachine>
+      <AdditionalLibraryDirectories>$(CONTRIB_PATH)\boost_1_84_0\stage\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
     <PostBuildEvent>
       <Command />

--- a/BootstrapperClient/BootstrapperClient.vcxproj
+++ b/BootstrapperClient/BootstrapperClient.vcxproj
@@ -79,7 +79,7 @@
     <IntDir>obj\$(Configuration)\$(PlatformName)\</IntDir>
     <LinkIncremental>true</LinkIncremental>
     <PostBuildEventUseInBuild>true</PostBuildEventUseInBuild>
-    <TargetName>PekoraPlayerLauncher</TargetName>
+    <TargetName>KoronePlayerLauncher</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <OutDir>$(Platform)\$(Configuration)\</OutDir>
@@ -92,13 +92,13 @@
     <IntDir>obj\$(Configuration)\$(PlatformName)\</IntDir>
     <LinkIncremental>true</LinkIncremental>
     <LibraryPath>$(CONTRIB_PATH)\boost_1_84_0\stage\lib;$(LibraryPath)</LibraryPath>
-    <TargetName>PekoraPlayerLauncher</TargetName>
+    <TargetName>KoronePlayerLauncher</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <OutDir>bin\$(Configuration)\$(PlatformName)\</OutDir>
     <IntDir>obj\$(Configuration)\$(PlatformName)\</IntDir>
     <LinkIncremental>true</LinkIncremental>
-    <TargetName>PekoraPlayerLauncher</TargetName>
+    <TargetName>KoronePlayerLauncher</TargetName>
   </PropertyGroup>
   <PropertyGroup Label="Vcpkg">
     <VcpkgEnableManifest>true</VcpkgEnableManifest>
@@ -129,7 +129,7 @@
     </ClCompile>
     <Link>
       <AdditionalDependencies>Iphlpapi.lib;taskschd.lib;mstask.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <OutputFile>$(OutDir)PekoraPlayerLauncher.exe</OutputFile>
+      <OutputFile>$(OutDir)KoronePlayerLauncher.exe</OutputFile>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <TargetMachine>MachineX86</TargetMachine>
@@ -160,7 +160,7 @@
     </ClCompile>
     <Link>
       <AdditionalDependencies>$(CONTRIB_PATH)\SDK\Lib\Iphlpapi.lib;$(CONTRIB_PATH)\SDK\Lib\taskschd.lib;$(CONTRIB_PATH)\SDK\Lib\mstask.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <OutputFile>$(OutDir)PekoraPlayerLauncher.exe</OutputFile>
+      <OutputFile>$(OutDir)KoronePlayerLauncher.exe</OutputFile>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <TargetMachine>MachineX64</TargetMachine>
@@ -191,7 +191,7 @@
     </ClCompile>
     <Link>
       <AdditionalDependencies>Iphlpapi.lib;taskschd.lib;mstask.lib;crypt32.lib;secur32.lib;bcrypt.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <OutputFile>$(OutDir)PekoraPlayerLauncher.exe</OutputFile>
+      <OutputFile>$(OutDir)KoronePlayerLauncher.exe</OutputFile>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>
@@ -226,7 +226,7 @@
     </ClCompile>
     <Link>
       <AdditionalDependencies>Iphlpapi.lib;taskschd.lib;mstask.lib;crypt32.lib;secur32.lib;bcrypt.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <OutputFile>$(OutDir)PekoraPlayerLauncher.exe</OutputFile>
+      <OutputFile>$(OutDir)KoronePlayerLauncher.exe</OutputFile>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>

--- a/ClientShared/Win/CookiesEngine.cpp
+++ b/ClientShared/Win/CookiesEngine.cpp
@@ -4,7 +4,7 @@
 #include "AtlBase.h"
 #include "AtlSync.h"
 
-const TCHAR rbxRegPath[] = _T("Software\\Pekora Corporation\\Pekora");
+const TCHAR rbxRegPath[] = _T("Software\\Korone Corporation\\Korone");
 const TCHAR rbxRegName[] = _T("CPath");
 const TCHAR CookieFileMutext[] = _T("RobloxCookieEngineMutex");
 

--- a/Roblox.inf
+++ b/Roblox.inf
@@ -2,7 +2,7 @@
     signature="$CHICAGO$"
     AdvancedINF=2.0 
 [Add.Code]
-    Pekora.exe=Pekora.exe
-[Pekora.exe]
+    Korone.exe=Korone.exe
+[Korone.exe]
     file-win32-x86=thiscab
     clsid={5FF8A30F-D08D-41CD-A03A-10346903902B}

--- a/Win/SharedLauncher.cpp
+++ b/Win/SharedLauncher.cpp
@@ -222,7 +222,7 @@ CRegKey GetKey(CString& out_operation, bool isStudioKey, bool is64bits)
 				launchMode = Play;
 			}
 
-			operation = "Start Pekora.exe";
+			operation = "Start Korone.exe";
 
 			TCHAR cmd[2048] = {0};
 
@@ -320,7 +320,7 @@ CRegKey GetKey(CString& out_operation, bool isStudioKey, bool is64bits)
 	try
 	{
 		ATL::CPath path = loadRobloxPath(operation, false);
-		operation = "Start Pekora.exe";
+		operation = "Start Korone.exe";
 
 		TCHAR cmd[2048];
 #ifdef UNICODE
@@ -414,7 +414,7 @@ CRegKey GetKey(CString& out_operation, bool isStudioKey, bool is64bits)
 	HRESULT hr = S_OK;
 	try
 	{
-		operation = "Update Pekora.exe";
+		operation = "Update Korone.exe";
 
 		ATL::CPath path;
 		{
@@ -459,7 +459,7 @@ CRegKey GetKey(CString& out_operation, bool isStudioKey, bool is64bits)
 	(*pVal) = VARIANT_FALSE;
 	try
 	{
-		operation = "IsUpToDate Pekora.exe";
+		operation = "IsUpToDate Korone.exe";
 
 		ATL::CPath path;
 		{

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,21 +1,54 @@
 {
   "name": "bootstrapper",
   "version": "1.0.0",
-  "builtin-baseline": "4bb07a326d9b9bce3703272a509e5bc25dd9cfd5",
+  "builtin-baseline": "7e19f3c64cb636ee21f41bfe8558a6dfaae6236f",
   "dependencies": [
+<<<<<<< Updated upstream
     "boost-asio",
     "boost-foreach",
     "boost-lexical-cast",
     "boost-property-tree",
     "boost-thread",
+=======
+    {
+      "name": "boost-asio",
+      "version>=": "1.81.0"
+    },
+    {
+      "name": "boost-foreach",
+      "version>=": "1.81.0"
+    },
+    {
+      "name": "boost-lexical-cast",
+      "version>=": "1.81.0"
+    },
+    {
+      "name": "boost-property-tree",
+      "version>=": "1.81.0"
+    },
+    {
+      "name": "boost-thread",
+      "version>=": "1.81.0"
+    },
+>>>>>>> Stashed changes
     {
       "name": "cpr",
+      "version>=": "1.9.3",
       "features": [
         "ssl"
       ]
     },
-    "rapidjson",
-    "zlib",
-    "minizip"
+    {
+      "name": "rapidjson",
+      "version>=": "2022-06-28#3"
+    },
+    {
+      "name": "zlib",
+      "version>=": "1.2.13"
+    },
+    {
+      "name": "minizip",
+      "version>=": "1.2.13"
+    }
   ]
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -6,7 +6,6 @@
     "boost-asio",
     "boost-foreach",
     "boost-lexical-cast",
-    "boost-lexical-cast",
     "boost-property-tree",
     "boost-thread",
     {


### PR DESCRIPTION
This PR includes two main changes:

1. **x86 Build Workflow & Project Updates**

   * Introduces a GitHub Actions workflow for building x86 (Win32) release artifacts.
   * Updates `Bootstrapper` and `BootstrapperClient` project files to:

     * Enable whole program optimization
     * Support static linking via vcpkg for Debug|x64 and Debug|Win32
     * Adjust output directories and names
     * Set C++23 standard for debug builds
     * Refine library dependencies
   * Updates `vcpkg.json` to specify minimum versions and a new baseline.
   * x64 GitHub Actions workflow coming soon.

2. **Rename Pekora References**

   * All strings and cross references previously named "Pekora" are now updated to "Korone".